### PR TITLE
Fixing conditional and validation structure for cb_buildspec_cmd

### DIFF
--- a/modules/aws/modules/cicd/main.tf
+++ b/modules/aws/modules/cicd/main.tf
@@ -62,7 +62,7 @@ resource "aws_codebuild_project" "codebuild" {
     source {
         type      = "GITHUB"
         location  = var.github_path
-        buildspec = var.cb_buildspec_cmd == {} ? "${var.cb_buildspec_path}buildspec-${var.github_branch}.yml" : templatefile("${path.module}/templates/${var.cb_buildspec_cmd["cmd"]}.yml.tpl", var.cb_buildspec_cmd["var"])
+        buildspec = var.cb_buildspec_cmd["cmd"] == "NA" ? "${var.cb_buildspec_path}buildspec-${var.github_branch}.yml" : templatefile("${path.module}/templates/${var.cb_buildspec_cmd["cmd"]}.yml.tpl", var.cb_buildspec_cmd["var"])
 
         auth {
             type     = "OAUTH"

--- a/modules/aws/modules/cicd/variables.tf
+++ b/modules/aws/modules/cicd/variables.tf
@@ -28,9 +28,9 @@ variable "artefact_bucket_name" {
 }
 
 variable "cb_buildspec_cmd" {
-    #type        = map() #Unable to set desired validation type
+    type        = object({ cmd = string, var = map(string) })
     description = "A map specifying the desired command and any required inputs. If left to default, it will be ignored and a buildspec file will be expected in repo"
-    default     = {}
+    default     = {"cmd" = "NA", "var" = {}}
 }
 
 variable "cb_buildspec_path" {


### PR DESCRIPTION
Fixing conditional and validation structure for cb_buildspec_cmd

This actually relates to an issue in terragrunt which this will hopefully fix. Even if it doesn't, it's an ideal change